### PR TITLE
Fixes #24 casued by atom-ide-ui

### DIFF
--- a/src/lib/menu-updater.ts
+++ b/src/lib/menu-updater.ts
@@ -239,12 +239,7 @@ export default class MenuUpdater {
                 .children[indexList[0]]
                 .getElementsByClassName("menu-box")[0];
             for (var i = 1; i < indexList.length - 1; i++) {
-                temp = Array.prototype.filter.call(temp.children, function(node: Element) {
-                    if (!node.classList.contains("menu-item"))
-                        return false;
-                    else return true;
-                })[indexList[i]];
-                temp = temp.getElementsByClassName("menu-box")[0];
+                temp = temp.children[indexList[i]].getElementsByClassName("menu-box")[0];
             }
             var traversed = this.titleBarReplacerView.traverseTemplate([template]);
             temp.insertBefore(traversed[0], temp.children[indexList[indexList.length - 1]]);

--- a/src/lib/title-bar-replacer-view.ts
+++ b/src/lib/title-bar-replacer-view.ts
@@ -397,8 +397,8 @@ export default class TitleBarReplacerView {
 	 * @param  {number} 		  insertIndex The index at which the menu label should be inserted
 	 */
 	public deserializeLabel(labelObject: TbrCore.MenuItem, insertIndex: number): void {
-
-		if (!labelObject.label || !labelObject.submenu) return; //Prevent crash upon accessing faulty menu items
+		var target = this.element.querySelector(".app-menu");
+		if (!labelObject.label || !labelObject.submenu || !target) return; //Prevent crash upon accessing faulty menu items
 
 		var menuLabel = document.createElement("span");
 		menuLabel.classList.add("menu-label");
@@ -416,8 +416,7 @@ export default class TitleBarReplacerView {
 		});
 
 		menuLabel.appendChild(menu);
-		customMenu.insertBefore(menuLabel, customMenu.children[insertIndex]);
-
+		target.insertBefore(menuLabel, target.children[insertIndex]);
 		this.initMenuItem(menuLabel, menu);
 
 	}


### PR DESCRIPTION
For the 1st commit. I removed the filter since the separators have been included in the MenuItem:
![image](https://user-images.githubusercontent.com/798943/97783102-68c7bc80-1bd0-11eb-82c2-57fcbefb8f27.png)

For the 2nd commit.  I use this.element instead as customElement already inserted into this.element anyway.
